### PR TITLE
small sample of TS-compatible type definitions for PosterizeNode.js

### DIFF
--- a/src/nodes/display/PosterizeNode.js
+++ b/src/nodes/display/PosterizeNode.js
@@ -1,5 +1,6 @@
 import TempNode from '../core/TempNode.js';
 import { nodeProxy } from '../tsl/TSLBase.js';
+/** @import Node from '../core/Node.js'  */
 
 /**
  * Represents a posterize effect which reduces the number of colors
@@ -57,7 +58,7 @@ export default PosterizeNode;
  * TSL function for creating a posterize node.
  *
  * @tsl
- * @function
+ * @type {function(Node, Node): PosterizeNode}
  * @param {Node} sourceNode - The input color.
  * @param {Node} stepsNode - Controls the intensity of the posterization effect. A lower number results in a more blocky appearance.
  * @returns {PosterizeNode}


### PR DESCRIPTION
small sample of making everything in PosterizeNode.js have TS-compatible type definitions

Related issue: #XXXX

**Description**

Shows how to format definitions that are compatible in downstream TS projects.

I have checked the doc generator, but this change may possibly break compatibility with that if the doc tool does not support TS-compatible JSDoc. If that's the case, we would need to either update that tool (possibly lots of work) or choose a different tool.

<!-- Remove the line below if is not relevant 

*This contribution is funded by [Example](https://example.com)*

-->